### PR TITLE
Fixed database table not found error in debug

### DIFF
--- a/o/celery.py
+++ b/o/celery.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from celery import Celery
 from importlib import import_module
 from django.conf import settings as django_settings
@@ -16,9 +17,14 @@ def configure_settings(DJANGO_SETTINGS_MODULE: str = 'settings'):
         if setting_name.isupper():
             setting_value = getattr(user_settings_module, setting_name)
             user_settings_dict[setting_name] = setting_value
+
+    # find the correct path of the sqlite database file
+    current_path = Path(os.path.dirname(__file__))
+    db_path = os.path.join(current_path.parent, "db.sqlite3")
+
     default_db = {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': "file::memory:?cache=shared",
+        'NAME': db_path,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -r requirements_base.txt
 psycopg2>=2.5.1
+celery


### PR DESCRIPTION
Hi Philipp,

In your implementation, celery looks for db.sqlite3 in the app folder "o", when it really is located in the parent, project folder.
The changes I made get celery to work in DEBUG, I did not test any production settings or a Postgres database. I guess it needs more changes, but at least celery works in DEBUG mode with an sqlite DB now.

This [Stack Overflow Answer](https://stackoverflow.com/questions/50212082/celery-importing-models-in-tasks-py) got me on the right track.

Cheers
Christian